### PR TITLE
chore: introduce devcontainer support

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,38 @@
+{
+	"name": "SENEC.Home V2.x/V3/V4 Systems development",
+	"image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.11-bullseye",
+	"postCreateCommand": "scripts/setup",
+	"forwardPorts": [
+		8123
+	],
+	"portsAttributes": {
+		"8123": {
+			"label": "Home Assistant",
+			"onAutoForward": "notify"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"github.vscode-pull-request-github",
+				"ryanluker.vscode-coverage-gutters",
+				"ms-python.vscode-pylance",
+				"ms-python.pylint"
+			],
+			"settings": {
+				"files.eol": "\n",
+				"editor.tabSize": 4,
+				"python.pythonPath": "/usr/bin/python3",
+				"python.analysis.autoSearchPaths": false,
+				"python.formatting.provider": "black",
+				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+				"editor.formatOnPaste": false,
+				"editor.formatOnSave": true,
+				"editor.formatOnType": true,
+				"files.trimTrailingWhitespace": true
+			}
+		}
+	},
+	"remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,7 @@ dmypy.json
 
 # virtual environment
 .venv
+
+# Home Assistant configuration
+config/*
+!config/configuration.yaml

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Home Assistant: Attach Local",
+            "type": "python",
+            "request": "attach",
+            "port": 5678,
+            "host": "localhost",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Home Assistant on port 8123",
+            "type": "shell",
+            "command": "scripts/develop",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/DEVELOPER_DOCUMENTATION.md
+++ b/DEVELOPER_DOCUMENTATION.md
@@ -1,10 +1,10 @@
 # Development Documentation
 This document should give an overview regarding the used APIs and the possible data that can be queried.
 
-## Data that can be accessed in the local network from a Senec V3 device 
+## Data that can be accessed in the local network from a Senec V3 device
 Basis for this documentation is the firmware version 0826.
 
-The following information are provided by the device. Since no open acceccible API documentation exists, the following description is an assumption. 
+The following information are provided by the device. Since no open acceccible API documentation exists, the following description is an assumption.
 - The following information can be accessed sending a post request with a JSON-Payload to https://[IP of the senec device]/lala.cgi
 - As response a JSON String is returned
 - Please note: Depending on the firmware version the Request has to be via http or https. (https starting with the firmware version 825)
@@ -543,13 +543,13 @@ Information represented by the BAT1OBJ1-Object:
 |TEMP4|0||
 |TEMP5|0||
 |U_DC|54.85300064086914||
-  
+
   ### Category BAT1OBJ2
   Information represented by the BAT1OBJ2-Object:
    "BAT1OBJ2":{
       "OBJECT_NOT_FOUND":""
    },
-  
+
   ### Category BAT1OBJ3
   Information represented by the BAT1OBJ3-Object:
    "BAT1OBJ3":{
@@ -656,7 +656,7 @@ Information represented by the CASC-Object:
 |SOC|[100.0, 100.0, 100.0, 100.0, 100.0, 100.0]||
 |STATE|[0, 0, 0, 0, 0, 0]||
 |TARGET|[0.0, 0.0, 0.0, 0.0, 0.0, 0.0]||
-  
+
 ### Category DISPLAY
 Returns an empty object
 
@@ -1049,7 +1049,7 @@ _Response_
 ```JSON
 
 {
-    "einspeisebegrenzungKwpInPercent": 100, #export limit in kwh in percent 
+    "einspeisebegrenzungKwpInPercent": 100, #export limit in kwh in percent
     "peakShavingMode": "DEACTIVATED", #Current mode DEACTIVATED, MANUAL, AUTO
     "peakShavingCapacityLimitInPercent": 0, #Battery capacity limit in percent
     "peakShavingLocalEndTime": [
@@ -1087,3 +1087,14 @@ To set the changed configuration call ("GET") the following URL and set the resp
 - Time of the day on which the capacity limitation should switch off again.
 
 
+## Test your code modification
+
+This custom component is based on [integration_blueprint template](https://github.com/ludeeus/integration_blueprint).
+
+It comes with development environment in a container, easy to launch
+if you use Visual Studio Code. With this container you will have a stand alone
+Home Assistant instance running and already configured with the included
+[`configuration.yaml`](./config/configuration.yaml)
+file.
+
+Inside the devcontainer run "scripts/develop" to start HA and test out your new integration. Use "Home Assistant: Attach Local" to attach debugger.

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,0 +1,13 @@
+# https://www.home-assistant.io/integrations/default_config/
+default_config:
+
+# https://www.home-assistant.io/integrations/logger/
+logger:
+  default: info
+  logs:
+    custom_components.integration_blueprint: debug
+
+
+# Example configuration.yaml entry
+debugpy:
+  start: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+colorlog==6.8.0
+homeassistant==2023.12.1
+pip>=23.3.1
+ruff==0.1.7
+# https://github.com/home-assistant/core/issues/95192
+urllib3>=1.26.5,<2

--- a/scripts/develop
+++ b/scripts/develop
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# Create config dir if not present
+if [[ ! -d "${PWD}/config" ]]; then
+    mkdir -p "${PWD}/config"
+    hass --config "${PWD}/config" --script ensure_config
+fi
+
+# Set the path to custom_components
+## This let's us have the structure we want <root>/custom_components/integration_blueprint
+## while at the same time have Home Assistant configuration inside <root>/config
+## without resulting to symlinks.
+export PYTHONPATH="${PYTHONPATH}:${PWD}/custom_components"
+
+# Start Home Assistant
+hass --config "${PWD}/config" --debug

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+ruff check . --fix

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+python3 -m pip install --requirement requirements.txt


### PR DESCRIPTION
Introduce devcontainer support based on https://github.com/ludeeus/integration_blueprint to ease development.

I wanted to start working on #56 but missed an easy way to start development with debugging support. I'm ready to sleep, but at least I can start coding tomorrow.

The config of the pre commit hooks like black and isort should be incorporated in the future and ruff shows some meaningful errors (scripts/lint).