### PR TITLE
fix: use async_create_clientsession instead of async_get_clientsession to prevent cookie leakage

### DIFF
--- a/custom_components/senec/__init__.py
+++ b/custom_components/senec/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_SCAN_INTERVAL, CONF_TYPE, CONF_NAME, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant, Event
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.entity import EntityDescription, Entity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers import entity_registry, event
@@ -85,7 +85,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
                                                                                      DEFAULT_SCAN_INTERVAL_SENECV2)))
 
     _LOGGER.info("Starting " + str(config_entry.data.get(CONF_NAME)) + " with interval: " + str(SCAN_INTERVAL))
-    session = async_get_clientsession(hass)
+    session = async_create_clientsession(hass)
 
     coordinator = SenecDataUpdateCoordinator(hass, session, config_entry)
     await coordinator.async_refresh()


### PR DESCRIPTION
This bugfix replaces all occurrences of async_get_clientsession with async_create_clientsession and as such prevents any cookie leakage between entries. If auto_cleanup couldn't be used (connection test), it is detached inside a finally block.

Looking up [aiohttp_client](https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/aiohttp_client.py) the session returned by the function "async_get_clientsession" seems to be at least bound to the whole component if not the whole thread. This was probably the reason for some of the custom cookie_jar code in there. The function "async_create_clientsession" in comparison is meant to be used inside the entry setup and gets destroyed when the entry is unloaded.

I tried not to refactor anything but fixing the issue at hand, but i would assume MySenecCookieJar could be added as parameter when creating the session instead of overwriting _cookie_jar and does not need so much code anymore (if any?). 

Fixes #56

![image](https://github.com/marq24/ha-senec-v3/assets/4943440/5f1eda00-bc40-476f-9c9f-10a8626bfc60)

BTW:
More votes than I expected, at least I'm not the only lazy one out there:
https://community.home-assistant.io/t/multiple-energy-dashboards/384719