### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/senec/pysenec_ha/__init__.py
+++ b/custom_components/senec/pysenec_ha/__init__.py
@@ -3798,10 +3798,10 @@ class MySenecWebPortal:
             try:
                 response.raise_for_status()
                 if 200 <= response.status <= 205:
-                    content = await response.text()
+                    content = int(await response.text())
                     if isinstance(content, Number):
                         self._QUERY_SPARE_CAPACITY_TS = time()
-                        self._spare_capacity = int(content)
+                        self._spare_capacity = content
                     else:
                         _LOGGER.info(f"spare_capacity is not a number - request to '{a_url}' returned: '{content}'")
                         self._spare_capacity = 0


### PR DESCRIPTION
This PR should take care, that the spare capacity is visible again and not "just" 0 as mentioned in #141.

Changes:
Line 3801: Added a cast to int. Otherwise the check in line 3802 will fail every time, since we receive an text from the response