### PR TITLE
SENEC WebApi has new option "Add wallbox consumption to own consumpti…

### DIFF
--- a/custom_components/senec/__init__.py
+++ b/custom_components/senec/__init__.py
@@ -54,6 +54,7 @@ from .const import (
     CONF_SYSTYPE_WEB,
     CONF_DEV_MASTER_NUM,
     CONF_IGNORE_SYSTEM_STATE,
+    CONF_INCLUDE_WALLBOX,
 
     MAIN_SENSOR_TYPES,
     MAIN_BIN_SENSOR_TYPES,
@@ -235,6 +236,10 @@ class SenecDataUpdateCoordinator(DataUpdateCoordinator):
             if CONF_DEV_MASTER_NUM in config_entry.data:
                 app_master_plant_number = int(config_entry.data[CONF_DEV_MASTER_NUM])
 
+            include_wallbox = True
+            if CONF_INCLUDE_WALLBOX in config_entry.data:
+               include_wallbox = config_entry.data[CONF_INCLUDE_WALLBOX]
+
             # user & pwd can be changed via the options...
             user = config_entry.data[CONF_USERNAME]
             pwd = config_entry.data[CONF_PASSWORD]
@@ -258,7 +263,8 @@ class SenecDataUpdateCoordinator(DataUpdateCoordinator):
                 QUERY_SPARE_CAPACITY_KEY: False,
                 QUERY_PEAK_SHAVING_KEY: False,
                 QUERY_TOTALS_KEY: False,
-                QUERY_SYSTEM_DETAILS_KEY: False
+                QUERY_SYSTEM_DETAILS_KEY: False,
+                CONF_INCLUDE_WALLBOX: include_wallbox
             }
 
             if hass is not None and config_entry.entry_id is not None and config_entry.title is not None:

--- a/custom_components/senec/const.py
+++ b/custom_components/senec/const.py
@@ -93,6 +93,7 @@ CONF_USE_HTTPS: Final = "use_https"
 CONF_SUPPORT_BDC: Final = "has_bdc_support"
 CONF_DEV_MASTER_NUM: Final = "master_plant_number"
 CONF_IGNORE_SYSTEM_STATE: Final = "ignore_system_state"
+CONF_INCLUDE_WALLBOX: Final = "include_wallbox"
 
 CONF_DEV_TYPE: Final = "dtype"
 CONF_DEV_MODEL: Final = "dname"
@@ -128,6 +129,7 @@ DEFAULT_SCAN_INTERVAL_SENECV2: Final = 60
 DEFAULT_SCAN_INTERVAL_WEB: Final = 300
 DEFAULT_SCAN_INTERVAL_WEB_SENECV4: Final = 60
 DEFAULT_MIN_SCAN_INTERVAL_WEB: Final = 20
+DEFAULT_INCLUDE_WALLBOX: Final = True
 
 QUERY_BMS_KEY: Final = "query_bms_data"
 QUERY_BMS_CELLS_KEY: Final = "query_bms_cells_data"

--- a/custom_components/senec/pysenec_ha/__init__.py
+++ b/custom_components/senec/pysenec_ha/__init__.py
@@ -45,6 +45,7 @@ from custom_components.senec.const import (
     CONF_APP_DATA_START,
     CONF_APP_DATA_END,
     CONF_APP_TOTAL_DATA,
+    CONF_INCLUDE_WALLBOX,
     DOMAIN
 )
 from custom_components.senec.pysenec_ha.constants import (
@@ -3017,6 +3018,12 @@ class SenecOnline:
             self._QUERY_SYSTEM_DETAILS = options[QUERY_SYSTEM_DETAILS_KEY]
         else:
             self._QUERY_SYSTEM_DETAILS = False
+
+        if options is not None and CONF_INCLUDE_WALLBOX in options:
+            self._INCLUDE_WALLBOX = options[CONF_INCLUDE_WALLBOX]
+        else:
+            self._INCLUDE_WALLBOX = True            
+
         # Variable to save the latest update time for system-details/system_state data…
         self._QUERY_SYSTEM_DETAILS_TS = 0
         self._QUERY_SYSTEM_STATE_TS = 0
@@ -3155,7 +3162,10 @@ class SenecOnline:
         self.APP_MEASURE_DATA_AVAIL     = self.APP_MEASURE_BASE_URL + "/v1/systems/{master_plant_id}/data-availability/timespan?timezone={tz}"
         self.APP_MEASURE_DASHBOARD      = self.APP_MEASURE_BASE_URL + "/v1/systems/{master_plant_id}/dashboard"
         self.APP_MEASURE_TOTAL          = self.APP_MEASURE_BASE_URL + "/v1/systems/{master_plant_id}/measurements?resolution={res_type}&from={from_val}&to={to_val}"
-        self.APP_MEASURE_TOTAL_WITH_WB  = self.APP_MEASURE_BASE_URL + "/v1/systems/{master_plant_id}/measurements?resolution={res_type}&from={from_val}&to={to_val}&wallboxIds={wb_ids}"
+        if self._INCLUDE_WALLBOX:
+           self.APP_MEASURE_TOTAL_WITH_WB  = self.APP_MEASURE_BASE_URL + "/v1/systems/{master_plant_id}/measurements?resolution={res_type}&from={from_val}&to={to_val}&wallboxIds={wb_ids}"
+        else:
+           self.APP_MEASURE_TOTAL_WITH_WB  = self.APP_MEASURE_TOTAL
         self.APP_MEASURE_WB_TOTAL       = self.APP_MEASURE_BASE_URL + "/v1/systems/{master_plant_id}/wallboxes/measurements?wallboxIds={wb_id}&resolution={res_type}&from={from_val}&to={to_val}"
 
         # https://senec-app-systems-proxy.prod.senec.dev/systems/settings/user-energy-settings?systemId={master_plant_id}

--- a/custom_components/senec/strings.json
+++ b/custom_components/senec/strings.json
@@ -20,7 +20,8 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
           "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
-          "master_plant_number": "[%key:common::config_flow::data::master_plant_number%]"
+          "master_plant_number": "[%key:common::config_flow::data::master_plant_number%]",
+          "include_wallbox": "[%key:common::config_flow::data::include_wallbox%]"
         }
       }
     },

--- a/custom_components/senec/translations/de.json
+++ b/custom_components/senec/translations/de.json
@@ -73,7 +73,8 @@
           "password": "Dein 'mein-senec.de' Passwort",
           "totp_secret": "Dein 'mein-senec.de' OTP-auth-Secret (wenn Du MFA einrichten musstest)",
           "scan_interval": "Aktualisierungsintervall in Sekunden [> 60 Sekunden (20 Sekunden für SENEC.Home V4|P4)]",
-          "master_plant_number": "Anlagennummer (Experten Einstellung: Nur bei mehreren Master Instanzen relevant - sonst 'Automatische Erkennung' verwenden)"
+          "master_plant_number": "Anlagennummer (Experten Einstellung: Nur bei mehreren Master Instanzen relevant - sonst 'Automatische Erkennung' verwenden)",
+          "include_wallbox": "Wallbox zu Eigenverbrauch hinzuzählen"
         }
       },
       "optional_websetup_required_info": {

--- a/custom_components/senec/translations/en.json
+++ b/custom_components/senec/translations/en.json
@@ -72,7 +72,8 @@
           "username": "Your 'mein-senec.de' username",
           "password": "Your 'mein-senec.de' password",
           "totp_secret": "Your 'mein-senec.de' OTP-auth-Secret (if you have been forced to configure MFA)",
-          "scan_interval": "Polling Interval in seconds [> 60 seconds (20 seconds for SENEC.Home V4|P4)]"
+          "scan_interval": "Polling Interval in seconds [> 60 seconds (20 seconds for SENEC.Home V4|P4)]",
+          "include_wallbox": "Add wallbox consumption to own consumption"
         }
       },
       "optional_websetup_required_info": {


### PR DESCRIPTION
…on". Default settings is true (original behavior)

Here are my changes for the case you're willing to add them to your repository...

I also found a small "bug":
The new configuration value "open-auth-secret" prevents to open "Reconfigure" without loosing all previous settings.
I removed the check when opening the configuration page...